### PR TITLE
Coordinated Reset Cache

### DIFF
--- a/HelpMyStreet.Utils/HelpMyStreet.Contracts/AddressService/Request/GetPostcodeCoordinatesRequest.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Contracts/AddressService/Request/GetPostcodeCoordinatesRequest.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using HelpMyStreet.Contracts.AddressService.Response;
+using MediatR;
+
+namespace HelpMyStreet.Contracts.AddressService.Request
+{
+    public class GetPostcodeCoordinatesRequest : IRequest<GetPostcodeCoordinatesResponse>
+    {
+        [Required]
+        public IEnumerable<string> Postcodes { get; set; }
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Contracts/AddressService/Response/GetPostcodeCoordinatesResponse.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Contracts/AddressService/Response/GetPostcodeCoordinatesResponse.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace HelpMyStreet.Contracts.AddressService.Response
+{
+    [DataContract(Name = "getPostcodeCoordinatesResponse")]
+    public class GetPostcodeCoordinatesResponse
+    {
+        [Required]
+        [DataMember(Name = "postcodeCoordinates")]
+        public IEnumerable<PostcodeCoordinate> PostcodeCoordinates { get; set; }
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Contracts/AddressService/Response/PostcodeCoordinate.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Contracts/AddressService/Response/PostcodeCoordinate.cs
@@ -1,0 +1,17 @@
+﻿using System.Runtime.Serialization;
+
+namespace HelpMyStreet.Contracts.AddressService.Response
+{
+    [DataContract(Name = "postcodeCoordinate")]
+    public class PostcodeCoordinate
+    {
+        [DataMember(Name = "pc")] // short names to reduce serialisation and network transfer time
+        public string Postcode { get; set; }
+
+        [DataMember(Name = "lat")]
+        public double Latitude { get; set; }
+
+        [DataMember(Name = "lng")]
+        public double Longitude { get; set; }
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.UnitTests/CoordinatedResetCacheTests.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.UnitTests/CoordinatedResetCacheTests.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using HelpMyStreet.Utils.CoordinatedResetCache;
+using Microsoft.Extensions.Internal;
+using Moq;
+using NUnit.Framework;
+using Polly.Caching.Memory;
+
+namespace HelpMyStreet.UnitTests
+{
+    public class CoordinatedResetCacheTests
+    {
+        private Mock<ISystemClock> _mockableDateTime;
+
+        private Mock<ITestDataGetter> _dataGetter1;
+        private Mock<ITestDataGetter> _dataGetter2;
+
+        private Func<Task<string>> _dataGetterDelegate1;
+        private Func<Task<string>> _dataGetterDelegate2;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _dataGetter1 = new Mock<ITestDataGetter>();
+            _dataGetter1.Setup(x => x.GetDataAsync()).ReturnsAsync("hello");
+            _dataGetterDelegate1 = async () =>
+            {
+                await Task.Delay(50);
+                return await _dataGetter1.Object.GetDataAsync();
+            };
+
+            _dataGetter2 = new Mock<ITestDataGetter>();
+            _dataGetter2.Setup(x => x.GetDataAsync()).ReturnsAsync("goodbye");
+            _dataGetterDelegate2 = async () =>
+            {
+                await Task.Delay(50);
+                return await _dataGetter2.Object.GetDataAsync();
+            };
+
+            _mockableDateTime = new Mock<ISystemClock>();
+        }
+
+
+        [Test]
+        public async Task CacheExpiresOnTheHour()
+        {
+            _mockableDateTime.Setup(x => x.UtcNow).Returns(new DateTime(2020, 04, 24, 15, 45, 00, 00, DateTimeKind.Utc));
+
+            Mock<IPollyMemoryCacheProvider> pollyMemoryCacheProvider = new Mock<IPollyMemoryCacheProvider>();
+
+            MemoryCacheProvider memoryCacheProvider = new Polly.Caching.Memory.MemoryCacheProvider(new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions()
+            {
+                Clock = _mockableDateTime.Object
+            }));
+            pollyMemoryCacheProvider.SetupGet(x => x.MemoryCacheProvider).Returns(memoryCacheProvider);
+
+
+            CoordinatedResetCache coordinatedResetCache = new CoordinatedResetCache(pollyMemoryCacheProvider.Object, _mockableDateTime.Object);
+
+            string result1 = await coordinatedResetCache.GetCachedDataAsync<string>(_dataGetterDelegate1, "key", CoordinatedResetCacheTime.OnHour);
+            string result2 = await coordinatedResetCache.GetCachedDataAsync<string>(_dataGetterDelegate1, "key", CoordinatedResetCacheTime.OnHour);
+
+            _mockableDateTime.Setup(x => x.UtcNow).Returns(new DateTime(2020, 04, 24, 16, 00, 00, 00, DateTimeKind.Utc));
+
+            string result3 = await coordinatedResetCache.GetCachedDataAsync<string>(_dataGetterDelegate1, "key", CoordinatedResetCacheTime.OnHour);
+            string result4 = await coordinatedResetCache.GetCachedDataAsync<string>(_dataGetterDelegate1, "key", CoordinatedResetCacheTime.OnHour);
+
+
+            Assert.AreEqual("hello", result1);
+            Assert.AreEqual("hello", result2);
+            Assert.AreEqual("hello", result3);
+            Assert.AreEqual("hello", result4);
+
+            _dataGetter1.Verify(x => x.GetDataAsync(), Times.Exactly(2));
+
+        }
+
+        [Test]
+        public async Task CacheExpiresOnTheMinute()
+        {
+            _mockableDateTime.Setup(x => x.UtcNow).Returns(new DateTime(2020, 04, 24, 15, 45, 00, 00, DateTimeKind.Utc));
+
+            Mock<IPollyMemoryCacheProvider> pollyMemoryCacheProvider = new Mock<IPollyMemoryCacheProvider>();
+
+            MemoryCacheProvider memoryCacheProvider = new Polly.Caching.Memory.MemoryCacheProvider(new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions()
+            {
+                Clock = _mockableDateTime.Object
+            }));
+            pollyMemoryCacheProvider.SetupGet(x => x.MemoryCacheProvider).Returns(memoryCacheProvider);
+
+
+            CoordinatedResetCache coordinatedResetCache = new CoordinatedResetCache(pollyMemoryCacheProvider.Object, _mockableDateTime.Object);
+
+            string result1 = await coordinatedResetCache.GetCachedDataAsync<string>(_dataGetterDelegate1, "key", CoordinatedResetCacheTime.OnMinute);
+            string result2 = await coordinatedResetCache.GetCachedDataAsync<string>(_dataGetterDelegate1, "key", CoordinatedResetCacheTime.OnMinute);
+
+            _mockableDateTime.Setup(x => x.UtcNow).Returns(new DateTime(2020, 04, 24, 15, 46, 00, 00, DateTimeKind.Utc));
+
+            string result3 = await coordinatedResetCache.GetCachedDataAsync<string>(_dataGetterDelegate1, "key", CoordinatedResetCacheTime.OnMinute);
+            string result4 = await coordinatedResetCache.GetCachedDataAsync<string>(_dataGetterDelegate1, "key", CoordinatedResetCacheTime.OnMinute);
+
+
+            Assert.AreEqual("hello", result1);
+            Assert.AreEqual("hello", result2);
+            Assert.AreEqual("hello", result3);
+            Assert.AreEqual("hello", result4);
+
+            _dataGetter1.Verify(x => x.GetDataAsync(), Times.Exactly(2));
+
+        }
+
+        [Test]
+        public async Task DataIsOnlyRetrievedOnceDuringConcurrentCalls()
+        {
+            _mockableDateTime.Setup(x => x.UtcNow).Returns(new DateTime(2020, 04, 24, 15, 45, 00, 00, DateTimeKind.Utc));
+
+            Mock<IPollyMemoryCacheProvider> pollyMemoryCacheProvider = new Mock<IPollyMemoryCacheProvider>();
+
+            MemoryCacheProvider memoryCacheProvider = new Polly.Caching.Memory.MemoryCacheProvider(new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions()
+            {
+                Clock = _mockableDateTime.Object
+            }));
+            pollyMemoryCacheProvider.SetupGet(x => x.MemoryCacheProvider).Returns(memoryCacheProvider);
+
+            CoordinatedResetCache coordinatedResetCache = new CoordinatedResetCache(pollyMemoryCacheProvider.Object, _mockableDateTime.Object);
+
+            ConcurrentBag<Task<string>> results = new ConcurrentBag<Task<string>>();
+            Parallel.For(0, 50, i =>
+            {
+                Task<string> result = coordinatedResetCache.GetCachedDataAsync<string>(_dataGetterDelegate1, "key", CoordinatedResetCacheTime.OnMinute);
+                results.Add(result);
+            });
+
+            await Task.WhenAll(results);
+
+            foreach (Task<string> result in results)
+            {
+                Assert.AreEqual("hello", await result);
+            }
+
+            _dataGetter1.Verify(x => x.GetDataAsync(), Times.Exactly(1));
+
+        }
+
+
+        [Test]
+        public async Task TwoSourcesOfData()
+        {
+            _mockableDateTime.Setup(x => x.UtcNow).Returns(new DateTime(2020, 04, 24, 15, 45, 00, 00, DateTimeKind.Utc));
+
+            Mock<IPollyMemoryCacheProvider> pollyMemoryCacheProvider = new Mock<IPollyMemoryCacheProvider>();
+
+            MemoryCacheProvider memoryCacheProvider = new Polly.Caching.Memory.MemoryCacheProvider(new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions()
+            {
+                Clock = _mockableDateTime.Object
+            }));
+            pollyMemoryCacheProvider.SetupGet(x => x.MemoryCacheProvider).Returns(memoryCacheProvider);
+
+
+            CoordinatedResetCache coordinatedResetCache = new CoordinatedResetCache(pollyMemoryCacheProvider.Object, _mockableDateTime.Object);
+
+            string result1 = await coordinatedResetCache.GetCachedDataAsync<string>(_dataGetterDelegate1, "key1", CoordinatedResetCacheTime.OnHour);
+            string result2 = await coordinatedResetCache.GetCachedDataAsync<string>(_dataGetterDelegate2, "key2", CoordinatedResetCacheTime.OnHour);
+
+            string result3 = await coordinatedResetCache.GetCachedDataAsync<string>(_dataGetterDelegate1, "key1", CoordinatedResetCacheTime.OnHour);
+            string result4 = await coordinatedResetCache.GetCachedDataAsync<string>(_dataGetterDelegate2, "key2", CoordinatedResetCacheTime.OnHour);
+
+            Assert.AreEqual("hello", result1);
+            Assert.AreEqual("goodbye", result2);
+            Assert.AreEqual("hello", result3);
+            Assert.AreEqual("goodbye", result4);
+
+            _dataGetter1.Verify(x => x.GetDataAsync(), Times.Exactly(1));
+            _dataGetter2.Verify(x => x.GetDataAsync(), Times.Exactly(1));
+
+        }
+
+        [Test]
+        public async Task TwoInstancesShareBackingMemory()
+        {
+            _mockableDateTime.Setup(x => x.UtcNow).Returns(new DateTime(2020, 04, 24, 15, 45, 00, 00, DateTimeKind.Utc));
+
+            Mock<IPollyMemoryCacheProvider> pollyMemoryCacheProvider = new Mock<IPollyMemoryCacheProvider>();
+
+            MemoryCacheProvider memoryCacheProvider = new Polly.Caching.Memory.MemoryCacheProvider(new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions()
+            {
+                Clock = _mockableDateTime.Object
+            }));
+            pollyMemoryCacheProvider.SetupGet(x => x.MemoryCacheProvider).Returns(memoryCacheProvider);
+
+
+            CoordinatedResetCache coordinatedResetCache1 = new CoordinatedResetCache(pollyMemoryCacheProvider.Object, _mockableDateTime.Object);
+            CoordinatedResetCache coordinatedResetCache2 = new CoordinatedResetCache(pollyMemoryCacheProvider.Object, _mockableDateTime.Object);
+
+            string result1 = await coordinatedResetCache1.GetCachedDataAsync<string>(_dataGetterDelegate1, "key", CoordinatedResetCacheTime.OnHour);
+            string result2 = await coordinatedResetCache2.GetCachedDataAsync<string>(_dataGetterDelegate1, "key", CoordinatedResetCacheTime.OnHour);
+
+
+            Assert.AreEqual("hello", result1);
+            Assert.AreEqual("hello", result2);
+
+            _dataGetter1.Verify(x => x.GetDataAsync(), Times.Exactly(1));
+
+        }
+
+
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.UnitTests/DistanceCalculatorTests.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.UnitTests/DistanceCalculatorTests.cs
@@ -1,0 +1,33 @@
+﻿using NUnit.Framework;
+using UserService.Core.Utils;
+
+namespace HelpMyStreet.UnitTests
+{
+    public class DistanceCalculatorTests
+    {
+        // latitudes, longitudes and distance taken from postcode IO
+        [TestCase(52.954885, -1.155263, 52.955491, -1.155413, 68.18827704)]
+        [TestCase(54.286959, -0.393904, 54.284261, -0.38845, 465.13933511)]
+        [TestCase(53.402961, -2.995571, 53.406163, -2.991088, 464.64088409)]
+        [TestCase(53.388313, -1.472253, 53.389387, -1.477352, 359.69046967)]
+        public void GetDistanceInMetres(double longitude, double latitude, double otherLongitude, double otherLatitude, double expectedDistanceInMetres)
+        {
+            DistanceCalculator distanceCalculator = new DistanceCalculator();
+            double result = distanceCalculator.GetDistanceInMetres(longitude, latitude, otherLongitude, otherLatitude);
+
+            Assert.IsTrue(result >= (expectedDistanceInMetres - 1) && result <= (expectedDistanceInMetres + 1));
+        }
+
+        [TestCase(52.954885, -1.155263, 52.955491, -1.155413, 0.042370231000954)]
+        [TestCase(54.286959, -0.393904, 54.284261, -0.38845, 0.289024183213781)]
+        [TestCase(53.402961, -2.995571, 53.406163, -2.991088, 0.288714460109212)]
+        [TestCase(53.388313, -1.472253, 53.389387, -1.477352, 0.223501295975255)]
+        public void GetDistanceInMiles(double longitude, double latitude, double otherLongitude, double otherLatitude, double expectedDistanceInMetres)
+        {
+            DistanceCalculator distanceCalculator = new DistanceCalculator();
+            double result = distanceCalculator.GetDistanceInMiles(longitude, latitude, otherLongitude, otherLatitude);
+
+            Assert.IsTrue(result >= (expectedDistanceInMetres - 0.01) && result <= (expectedDistanceInMetres + 0.01));
+        }
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.UnitTests/DistanceConverterTests.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.UnitTests/DistanceConverterTests.cs
@@ -22,5 +22,13 @@ namespace HelpMyStreet.UnitTests
 
             Assert.AreEqual(1609, result);
         }
+
+        [Test]
+        public void ConvertMetresToMiles_MetresIsDouble()
+        {
+            double result = DistanceConverter.MetresToMiles(1000d);
+
+            Assert.AreEqual(0.621371, Math.Round(result, 6));
+        }
     }
 }

--- a/HelpMyStreet.Utils/HelpMyStreet.UnitTests/HelpMyStreet.UnitTests.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.UnitTests/HelpMyStreet.UnitTests.csproj
@@ -7,9 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Moq" Version="4.14.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
+    <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HelpMyStreet.Utils/HelpMyStreet.UnitTests/ITestDataGetter.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.UnitTests/ITestDataGetter.cs
@@ -1,0 +1,6 @@
+﻿using System.Threading.Tasks;
+
+public interface ITestDataGetter
+{
+    Task<string> GetDataAsync();
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/CoordinatedResetCache.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/CoordinatedResetCache.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.Extensions.Internal;
+using Polly;
+using Polly.Caching;
+using Polly.Contrib.DuplicateRequestCollapser;
+using System;
+using System.Threading.Tasks;
+
+namespace HelpMyStreet.Utils.CoordinatedResetCache
+{
+    public class CoordinatedResetCache : ICoordinatedResetCache
+    {
+        private readonly IPollyMemoryCacheProvider _pollyMemoryCacheProvider;
+        private readonly ISystemClock _mockableDateTime;
+
+        private static readonly IAsyncRequestCollapserPolicy _collapserPolicy = AsyncRequestCollapserPolicy.Create();
+
+        public CoordinatedResetCache(IPollyMemoryCacheProvider pollyMemoryCacheProvider, ISystemClock mockableDateTime)
+        {
+            _pollyMemoryCacheProvider = pollyMemoryCacheProvider;
+            _mockableDateTime = mockableDateTime;
+        }
+
+        public async Task<T> GetCachedDataAsync<T>(Func<Task<T>> dataGetter, string key, CoordinatedResetCacheTime resetCacheTime = CoordinatedResetCacheTime.OnHour)
+        {
+            TimeSpan timeToReset;
+
+            switch (resetCacheTime)
+            {
+                case CoordinatedResetCacheTime.OnHour:
+                    timeToReset = GetLengthOfTimeUntilNextHour();
+                    break;
+                case CoordinatedResetCacheTime.OnMinute:
+                    timeToReset = GetLengthOfTimeUntilNextMinute();
+                    break;
+            }
+
+            AsyncCachePolicy cachePolicy = Policy.CacheAsync(_pollyMemoryCacheProvider.MemoryCacheProvider, timeToReset);
+
+            Context context = new Context($"{nameof(CoordinatedResetCache)}_{key}");
+
+            // collapser policy used to prevent concurrent calls retrieving the same data twice
+            T result = await _collapserPolicy.WrapAsync(cachePolicy).ExecuteAsync(_ => dataGetter.Invoke(), context);
+
+            return result;
+        }
+
+        private TimeSpan GetLengthOfTimeUntilNextHour()
+        {
+            DateTimeOffset timeNow = _mockableDateTime.UtcNow;
+            DateTimeOffset nowPlusOneMinute = timeNow.AddHours(1);
+            DateTimeOffset theNextMinuteWithoutSeconds = new DateTime(nowPlusOneMinute.Year, nowPlusOneMinute.Month, nowPlusOneMinute.Day, nowPlusOneMinute.Hour, 0, 0, DateTimeKind.Utc);
+            TimeSpan timeSpanUntilNextMinute = theNextMinuteWithoutSeconds - timeNow;
+            return timeSpanUntilNextMinute;
+        }
+
+        private TimeSpan GetLengthOfTimeUntilNextMinute()
+        {
+            DateTimeOffset timeNow = _mockableDateTime.UtcNow;
+            DateTimeOffset nowPlusOneMinute = timeNow.AddMinutes(1);
+            DateTimeOffset theNextMinuteWithoutSeconds = new DateTime(nowPlusOneMinute.Year, nowPlusOneMinute.Month, nowPlusOneMinute.Day, nowPlusOneMinute.Hour, nowPlusOneMinute.Minute, 0, DateTimeKind.Utc);
+            TimeSpan timeSpanUntilNextMinute = theNextMinuteWithoutSeconds - timeNow;
+            return timeSpanUntilNextMinute;
+        }
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/CoordinatedResetCacheTime.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/CoordinatedResetCacheTime.cs
@@ -1,0 +1,8 @@
+﻿namespace HelpMyStreet.Utils.CoordinatedResetCache
+{
+    public enum CoordinatedResetCacheTime
+    {
+        OnMinute = 1,
+        OnHour = 10
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/ICoordinatedResetCache.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/ICoordinatedResetCache.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace HelpMyStreet.Utils.CoordinatedResetCache
+{
+    public interface ICoordinatedResetCache
+    {
+        /// <summary>
+        ///  Get data from cache. Cache expires on the hour or minute so all servers are kept in sync. IPollyMemoryCacheProvider and ISystemClock must be registered in DI (can use PollyMemoryCacheProvider and MockableDateTime implementations).
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="dataGetter">Delegate that return data</param>
+        /// <param name="key">The key to store data under</param>
+        /// <param name="resetCacheTime">When cache should reset</param>
+        /// <returns></returns>
+        Task<T> GetCachedDataAsync<T>(Func<Task<T>> dataGetter, string key, CoordinatedResetCacheTime resetCacheTime);
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/IPollyMemoryCacheProvider.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/IPollyMemoryCacheProvider.cs
@@ -1,0 +1,9 @@
+﻿using Polly.Caching.Memory;
+
+namespace HelpMyStreet.Utils.CoordinatedResetCache
+{
+    public interface IPollyMemoryCacheProvider
+    {
+        MemoryCacheProvider MemoryCacheProvider { get; }
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/PollyMemoryCacheProvider.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/PollyMemoryCacheProvider.cs
@@ -1,0 +1,11 @@
+﻿using Polly.Caching.Memory;
+
+namespace HelpMyStreet.Utils.CoordinatedResetCache
+{
+    public class PollyMemoryCacheProvider : IPollyMemoryCacheProvider
+    {
+        private static Polly.Caching.Memory.MemoryCacheProvider _memoryCacheProvider = new Polly.Caching.Memory.MemoryCacheProvider(new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions()));
+
+        public MemoryCacheProvider MemoryCacheProvider => _memoryCacheProvider;
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
@@ -9,4 +9,9 @@
     <Description>Shared Utilty Class for the HelpMyStreet Project.</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
+    <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.0" />
+  </ItemGroup>
+
 </Project>

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/Utils/DistanceCalculator.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/Utils/DistanceCalculator.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using HelpMyStreet.Utils.Utils;
+
+namespace UserService.Core.Utils
+{
+    public class DistanceCalculator : IDistanceCalculator
+    {
+
+        public double GetDistanceInMetres(double latitude, double longitude, double otherLatitude, double otherLongitude)
+        {
+            // Stolen from Microsoft's GeoCoordinate class (not yet available for .Net Core)
+            double d1 = latitude * (Math.PI / 180.0);
+            double num1 = longitude * (Math.PI / 180.0);
+            double d2 = otherLatitude * (Math.PI / 180.0);
+            double num2 = otherLongitude * (Math.PI / 180.0) - num1;
+            double d3 = Math.Pow(Math.Sin((d2 - d1) / 2.0), 2.0) + Math.Cos(d1) * Math.Cos(d2) * Math.Pow(Math.Sin(num2 / 2.0), 2.0);
+            return 6376500.0 * (2.0 * Math.Atan2(Math.Sqrt(d3), Math.Sqrt(1.0 - d3)));
+        }
+
+        public double GetDistanceInMiles(double latitude, double longitude, double otherLatitude, double otherLongitude)
+        {
+            var distanceInMetres = GetDistanceInMetres(latitude, longitude, otherLatitude, otherLongitude);
+            var distanceInMiles = DistanceConverter.MetresToMiles(distanceInMetres);
+            return distanceInMiles;
+        }
+
+    }
+
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/Utils/DistanceConverter.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/Utils/DistanceConverter.cs
@@ -13,5 +13,9 @@ namespace HelpMyStreet.Utils.Utils
         {
             return metres / 1609.344d;
         }
+        public static double MetresToMiles(double metres)
+        {
+            return metres / 1609.344d;
+        }
     }
 }

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/Utils/IDistanceCalculator.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/Utils/IDistanceCalculator.cs
@@ -1,0 +1,9 @@
+﻿namespace UserService.Core.Utils
+{
+    public interface IDistanceCalculator
+    {
+        double GetDistanceInMetres(double longitude, double latitude, double otherLongitude, double otherLatitude);
+
+        double GetDistanceInMiles(double longitude, double latitude, double otherLongitude, double otherLatitude);
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/Utils/MockableDateTime.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/Utils/MockableDateTime.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using Microsoft.Extensions.Internal;
+
+namespace HelpMyStreet.Utils.Utils
+{
+    public class MockableDateTime : ISystemClock
+    {
+        public DateTimeOffset UtcNow => DateTime.UtcNow;
+    }
+}


### PR DESCRIPTION
This cache can expire either on the hour or the minute so servers are kept in sync.  The data is only retrieved once for concurrent requests for the same key.

This PR also includes bits required for implementing showing volunteers on Google Maps.