### PR TITLE
Polly Retry Policies

### DIFF
--- a/HelpMyStreet.Utils/HelpMyStreet.UnitTests/IServiceCaller.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.UnitTests/IServiceCaller.cs
@@ -1,0 +1,10 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace HelpMyStreet.UnitTests
+{
+    public interface IServiceCaller
+    {
+        Task<HttpResponseMessage> GetAsync();
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.UnitTests/PollyHttpPoliciesTests.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.UnitTests/PollyHttpPoliciesTests.cs
@@ -1,0 +1,99 @@
+﻿using HelpMyStreet.Utils.PollyPolicies;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace HelpMyStreet.UnitTests
+{
+    public class PollyHttpPoliciesTests
+    {
+        private Mock<IPollyHttpPoliciesConfig> _pollyHttpPoliciesConfig;
+
+        private Mock<IServiceCaller> _serviceCaller;
+        
+        [SetUp]
+        public void SetUp()
+        {
+            TimeSpan[] pausesOnError = new TimeSpan[]
+            {
+                TimeSpan.FromMilliseconds(1),
+                TimeSpan.FromMilliseconds(1),
+                TimeSpan.FromMilliseconds(1),
+                TimeSpan.FromMilliseconds(1),
+                TimeSpan.FromMilliseconds(1),
+                TimeSpan.FromMilliseconds(1),
+                TimeSpan.FromMilliseconds(1),
+                TimeSpan.FromMilliseconds(1)
+            };
+
+            _pollyHttpPoliciesConfig = new Mock<IPollyHttpPoliciesConfig>();
+
+            _pollyHttpPoliciesConfig.SetupGet(x => x.ServiceErrorPauses).Returns(pausesOnError);
+            _pollyHttpPoliciesConfig.SetupGet(x => x.AzureFunctionNotStartedPauses).Returns(pausesOnError);
+
+        }
+
+        [Test]
+        public async Task ExternalHttpRetryPolicy()
+        {
+            _serviceCaller = new Mock<IServiceCaller>();
+            _serviceCaller.SetupSequence(x => x.GetAsync())
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadGateway))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.GatewayTimeout))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InsufficientStorage))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+            PollyHttpPolicies pollyHttpPolicies = new PollyHttpPolicies(_pollyHttpPoliciesConfig.Object);
+
+            HttpResponseMessage result = await pollyHttpPolicies.ExternalHttpRetryPolicy.ExecuteAsync(async () => await _serviceCaller.Object.GetAsync());
+            Assert.AreEqual(200, (int)result.StatusCode);
+        }
+
+        [Test]
+        public async Task InternalHttpRetryPolicy()
+        {
+            _serviceCaller = new Mock<IServiceCaller>();
+            _serviceCaller.SetupSequence(x => x.GetAsync())
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadGateway))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.GatewayTimeout))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InsufficientStorage))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+            PollyHttpPolicies pollyHttpPolicies = new PollyHttpPolicies(_pollyHttpPoliciesConfig.Object);
+
+            HttpResponseMessage result = await pollyHttpPolicies.InternalHttpRetryPolicy.ExecuteAsync(async () => await _serviceCaller.Object.GetAsync());
+            Assert.AreEqual(200, (int)result.StatusCode);
+
+            _serviceCaller.Verify(x => x.GetAsync(), Times.Exactly(7));
+        }
+
+        [Test]
+        public async Task InternalHttpRetryPolicy_CorrectWaitTimesAreUsedWhenServiceUnavailable()
+        {
+            _pollyHttpPoliciesConfig.SetupGet(x => x.AzureFunctionNotStartedPauses).Returns(new TimeSpan[0]);
+
+            _serviceCaller = new Mock<IServiceCaller>();
+            _serviceCaller.SetupSequence(x => x.GetAsync())
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadGateway))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadGateway))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+            PollyHttpPolicies pollyHttpPolicies = new PollyHttpPolicies(_pollyHttpPoliciesConfig.Object);
+
+            HttpResponseMessage result = await pollyHttpPolicies.InternalHttpRetryPolicy.ExecuteAsync(async () => await _serviceCaller.Object.GetAsync());
+
+            Assert.AreEqual(503, (int)result.StatusCode); // shows the correct wait times were used for ServiceUnavailable (since it was empty the ServiceUnavailable is returned)
+        }
+
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
     <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.0" />
   </ItemGroup>

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/PollyPolicies/IPollyHttpPolicies.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/PollyPolicies/IPollyHttpPolicies.cs
@@ -1,0 +1,22 @@
+﻿using Polly.Retry;
+using Polly.Wrap;
+using System.Net.Http;
+
+namespace HelpMyStreet.Utils.PollyPolicies
+{
+    /// <summary>
+    /// HTTP retry policies. This has a dependency on IPollyHttpPoliciesConfig so it must be registered in the DI (PollyHttpPoliciesConfig is an implementation).
+    /// </summary>
+    public interface IPollyHttpPolicies
+    {
+        /// <summary>
+        /// Retries on 408 and 5XX errors.  503 errors have a different config for the pause between retires to allow time for the Azure Function to start up.
+        /// </summary>
+        AsyncPolicyWrap<HttpResponseMessage> InternalHttpRetryPolicy { get; }
+
+        /// <summary>
+        /// Retries on 408 and 5XX errors.
+        /// </summary>
+        AsyncRetryPolicy<HttpResponseMessage> ExternalHttpRetryPolicy { get; }
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/PollyPolicies/IPollyHttpPolicies.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/PollyPolicies/IPollyHttpPolicies.cs
@@ -1,6 +1,7 @@
 ﻿using Polly.Retry;
 using Polly.Wrap;
 using System.Net.Http;
+using Polly;
 
 namespace HelpMyStreet.Utils.PollyPolicies
 {
@@ -12,11 +13,11 @@ namespace HelpMyStreet.Utils.PollyPolicies
         /// <summary>
         /// Retries on 408 and 5XX errors.  503 errors have a different config for the pause between retires to allow time for the Azure Function to start up.
         /// </summary>
-        AsyncPolicyWrap<HttpResponseMessage> InternalHttpRetryPolicy { get; }
+        IAsyncPolicy<HttpResponseMessage> InternalHttpRetryPolicy { get; }
 
         /// <summary>
         /// Retries on 408 and 5XX errors.
         /// </summary>
-        AsyncRetryPolicy<HttpResponseMessage> ExternalHttpRetryPolicy { get; }
+        IAsyncPolicy<HttpResponseMessage> ExternalHttpRetryPolicy { get; }
     }
 }

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/PollyPolicies/IPollyHttpPoliciesConfig.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/PollyPolicies/IPollyHttpPoliciesConfig.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace HelpMyStreet.Utils.PollyPolicies
+{
+    public interface IPollyHttpPoliciesConfig
+    {
+        TimeSpan[] AzureFunctionNotStartedPauses { get; }
+        TimeSpan[] ServiceErrorPauses { get; }
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/PollyPolicies/PollyHttpPolicies.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/PollyPolicies/PollyHttpPolicies.cs
@@ -1,0 +1,35 @@
+﻿using Polly;
+using Polly.Retry;
+using Polly.Wrap;
+using System.Net;
+using System.Net.Http;
+
+namespace HelpMyStreet.Utils.PollyPolicies
+{
+    /// <inheritdoc />>
+    public class PollyHttpPolicies : IPollyHttpPolicies
+    {
+        /// <inheritdoc />>
+        public AsyncPolicyWrap<HttpResponseMessage> InternalHttpRetryPolicy { get; }
+
+        /// <inheritdoc />>
+        public AsyncRetryPolicy<HttpResponseMessage> ExternalHttpRetryPolicy { get; }
+
+        public PollyHttpPolicies(IPollyHttpPoliciesConfig pollyHttpPoliciesConfig)
+        {
+            AsyncRetryPolicy<HttpResponseMessage> otherHttpRetryPolicy = Policy
+                .HandleResult<HttpResponseMessage>(message => message.StatusCode != HttpStatusCode.ServiceUnavailable && (message.StatusCode == HttpStatusCode.RequestTimeout || ((int)message.StatusCode >= 500 && (int)message.StatusCode < 600))) // HTTP errors that don't indicate that Azure Function not running
+                .WaitAndRetryAsync(pollyHttpPoliciesConfig.ServiceErrorPauses);
+
+            AsyncRetryPolicy<HttpResponseMessage> azureFunctionHttpsRetryPolicy = Policy
+                .HandleResult<HttpResponseMessage>(message => message.StatusCode == HttpStatusCode.ServiceUnavailable) // HTTP error that indicates Azure Function not running
+                .WaitAndRetryAsync(pollyHttpPoliciesConfig.AzureFunctionNotStartedPauses);
+
+            InternalHttpRetryPolicy = Policy.WrapAsync(otherHttpRetryPolicy, azureFunctionHttpsRetryPolicy);
+            
+            ExternalHttpRetryPolicy = Policy
+                .HandleResult<HttpResponseMessage>(message => message.StatusCode == HttpStatusCode.RequestTimeout || ((int)message.StatusCode >= 500 && (int)message.StatusCode < 600))
+                .WaitAndRetryAsync(pollyHttpPoliciesConfig.ServiceErrorPauses);
+        }
+    }
+}

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/PollyPolicies/PollyHttpPolicies.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/PollyPolicies/PollyHttpPolicies.cs
@@ -1,6 +1,4 @@
 ﻿using Polly;
-using Polly.Retry;
-using Polly.Wrap;
 using System.Net;
 using System.Net.Http;
 
@@ -10,18 +8,18 @@ namespace HelpMyStreet.Utils.PollyPolicies
     public class PollyHttpPolicies : IPollyHttpPolicies
     {
         /// <inheritdoc />>
-        public AsyncPolicyWrap<HttpResponseMessage> InternalHttpRetryPolicy { get; }
+        public IAsyncPolicy<HttpResponseMessage> InternalHttpRetryPolicy { get; }
 
         /// <inheritdoc />>
-        public AsyncRetryPolicy<HttpResponseMessage> ExternalHttpRetryPolicy { get; }
+        public IAsyncPolicy<HttpResponseMessage> ExternalHttpRetryPolicy { get; }
 
         public PollyHttpPolicies(IPollyHttpPoliciesConfig pollyHttpPoliciesConfig)
         {
-            AsyncRetryPolicy<HttpResponseMessage> otherHttpRetryPolicy = Policy
+            IAsyncPolicy<HttpResponseMessage> otherHttpRetryPolicy = Policy
                 .HandleResult<HttpResponseMessage>(message => message.StatusCode != HttpStatusCode.ServiceUnavailable && (message.StatusCode == HttpStatusCode.RequestTimeout || ((int)message.StatusCode >= 500 && (int)message.StatusCode < 600))) // HTTP errors that don't indicate that Azure Function not running
                 .WaitAndRetryAsync(pollyHttpPoliciesConfig.ServiceErrorPauses);
 
-            AsyncRetryPolicy<HttpResponseMessage> azureFunctionHttpsRetryPolicy = Policy
+            IAsyncPolicy<HttpResponseMessage> azureFunctionHttpsRetryPolicy = Policy
                 .HandleResult<HttpResponseMessage>(message => message.StatusCode == HttpStatusCode.ServiceUnavailable) // HTTP error that indicates Azure Function not running
                 .WaitAndRetryAsync(pollyHttpPoliciesConfig.AzureFunctionNotStartedPauses);
 

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/PollyPolicies/PollyHttpPoliciesConfig.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/PollyPolicies/PollyHttpPoliciesConfig.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace HelpMyStreet.Utils.PollyPolicies
+{
+    public class PollyHttpPoliciesConfig : IPollyHttpPoliciesConfig
+    {
+        public TimeSpan[] AzureFunctionNotStartedPauses { get; }
+
+        public TimeSpan[] ServiceErrorPauses { get; }
+
+
+        public PollyHttpPoliciesConfig()
+        {
+            AzureFunctionNotStartedPauses = new[]
+            {
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(5),
+                TimeSpan.FromSeconds(10),
+                TimeSpan.FromSeconds(20),
+                TimeSpan.FromSeconds(40),
+                TimeSpan.FromSeconds(60)
+            };
+
+            ServiceErrorPauses = new[]
+            {
+                TimeSpan.FromSeconds(0.1),
+                TimeSpan.FromSeconds(0.25),
+                TimeSpan.FromSeconds(0.5)
+            };
+        }
+    }
+}


### PR DESCRIPTION
Separate pause config is used for 503s for internal services because this indicates an Azure Function has stopped running due to inactivity and it can wait for a much longer period before retrying.