### PR TITLE
Add non async method in CoordinatedResetCache class

### DIFF
--- a/HelpMyStreet.Utils/HelpMyStreet.UnitTests/ITestDataGetter.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.UnitTests/ITestDataGetter.cs
@@ -3,4 +3,5 @@
 public interface ITestDataGetter
 {
     Task<string> GetDataAsync();
+    string GetData();
 }

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/CoordinatedResetCache.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/CoordinatedResetCache.cs
@@ -20,6 +20,7 @@ namespace HelpMyStreet.Utils.CoordinatedResetCache
             _mockableDateTime = mockableDateTime;
         }
 
+        /// <inheritdoc />>
         public async Task<T> GetCachedDataAsync<T>(Func<Task<T>> dataGetter, string key, CoordinatedResetCacheTime resetCacheTime = CoordinatedResetCacheTime.OnHour)
         {
             TimeSpan timeToReset;
@@ -42,6 +43,12 @@ namespace HelpMyStreet.Utils.CoordinatedResetCache
             T result = await _collapserPolicy.WrapAsync(cachePolicy).ExecuteAsync(_ => dataGetter.Invoke(), context);
 
             return result;
+        }
+
+        /// <inheritdoc />>
+        public T GetCachedData<T>(Func<T> dataGetter, string key, CoordinatedResetCacheTime resetCacheTime = CoordinatedResetCacheTime.OnHour)
+        {
+            return GetCachedDataAsync(() => Task.FromResult(dataGetter.Invoke()), key, resetCacheTime).Result;
         }
 
         private TimeSpan GetLengthOfTimeUntilNextHour()

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/ICoordinatedResetCache.cs
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/CoordinatedResetCache/ICoordinatedResetCache.cs
@@ -14,5 +14,15 @@ namespace HelpMyStreet.Utils.CoordinatedResetCache
         /// <param name="resetCacheTime">When cache should reset</param>
         /// <returns></returns>
         Task<T> GetCachedDataAsync<T>(Func<Task<T>> dataGetter, string key, CoordinatedResetCacheTime resetCacheTime);
+
+        /// <summary>
+        ///  Get data from cache. Cache expires on the hour or minute so all servers are kept in sync. IPollyMemoryCacheProvider and ISystemClock must be registered in DI (can use PollyMemoryCacheProvider and MockableDateTime implementations).
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="dataGetter">Delegate that return data</param>
+        /// <param name="key">The key to store data under</param>
+        /// <param name="resetCacheTime">When cache should reset</param>
+        /// <returns></returns>
+        T GetCachedData<T>(Func<T> dataGetter, string key, CoordinatedResetCacheTime resetCacheTime);
     }
 }


### PR DESCRIPTION
Sometimes you want to cache something that isn't async (e.g. calculating min distances between lat/longs).  This is just a wrapper around the async version and means you don't have to wrap your own code with Task.FromResult().