### PR TITLE
Automatic update of 17 packages

### DIFF
--- a/HelpMyStreet.Utils/HelpMyStreet.Cache/HelpMyStreet.Cache.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Cache/HelpMyStreet.Cache.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.8" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
     <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.1" />

--- a/HelpMyStreet.Utils/HelpMyStreet.Cache/HelpMyStreet.Cache.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Cache/HelpMyStreet.Cache.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
-    <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.0" />
+    <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.1" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
   </ItemGroup>
 

--- a/HelpMyStreet.Utils/HelpMyStreet.Cache/HelpMyStreet.Cache.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Cache/HelpMyStreet.Cache.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Polly" Version="7.2.0" />
+    <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
     <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.0" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />

--- a/HelpMyStreet.Utils/HelpMyStreet.Cache/HelpMyStreet.Cache.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Cache/HelpMyStreet.Cache.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.8" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />

--- a/HelpMyStreet.Utils/HelpMyStreet.Contracts/HelpMyStreet.Contracts.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Contracts/HelpMyStreet.Contracts.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="8.0.1" />
+    <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/HelpMyStreet.Utils/HelpMyStreet.PostcodeCoordinates.EF/HelpMyStreet.PostcodeCoordinates.EF.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.PostcodeCoordinates.EF/HelpMyStreet.PostcodeCoordinates.EF.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.0" />
   </ItemGroup>

--- a/HelpMyStreet.Utils/HelpMyStreet.PostcodeCoordinates.EF/HelpMyStreet.PostcodeCoordinates.EF.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.PostcodeCoordinates.EF/HelpMyStreet.PostcodeCoordinates.EF.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.0" />
   </ItemGroup>
 

--- a/HelpMyStreet.Utils/HelpMyStreet.PostcodeCoordinates.EF/HelpMyStreet.PostcodeCoordinates.EF.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.PostcodeCoordinates.EF/HelpMyStreet.PostcodeCoordinates.EF.csproj
@@ -11,7 +11,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/HelpMyStreet.Utils/HelpMyStreet.UnitTests/HelpMyStreet.UnitTests.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.UnitTests/HelpMyStreet.UnitTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
     <PackageReference Include="Moq" Version="4.14.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
     <PackageReference Include="Polly.Caching.MemoryCache" Version="1.1.0" />

--- a/HelpMyStreet.Utils/HelpMyStreet.UnitTests/HelpMyStreet.UnitTests.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.UnitTests/HelpMyStreet.UnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
-    <PackageReference Include="Moq" Version="4.14.0" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />

--- a/HelpMyStreet.Utils/HelpMyStreet.UnitTests/HelpMyStreet.UnitTests.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.UnitTests/HelpMyStreet.UnitTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
     <PackageReference Include="Moq" Version="4.14.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />

--- a/HelpMyStreet.Utils/HelpMyStreet.UnitTests/HelpMyStreet.UnitTests.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.UnitTests/HelpMyStreet.UnitTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
     <PackageReference Include="Polly.Caching.MemoryCache" Version="1.1.0" />
-    <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.0" />
+    <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HelpMyStreet.Utils/HelpMyStreet.UnitTests/HelpMyStreet.UnitTests.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.UnitTests/HelpMyStreet.UnitTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
     <PackageReference Include="Polly.Caching.MemoryCache" Version="1.1.0" />
     <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.1" />

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
     <PackageReference Include="NewRelic.Agent.Api" Version="8.27.139" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Polly" Version="7.2.1" />

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
-    <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.0" />
+    <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
   </ItemGroup>

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
     <PackageReference Include="NewRelic.Agent.Api" Version="8.27.139" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="NewRelic.Agent.Api" Version="8.27.139" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
     <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.1" />

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="NewRelic.Agent.Api" Version="8.27.139" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Polly" Version="7.2.0" />
+    <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
     <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="NewRelic.Agent.Api" Version="8.27.139" />

--- a/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
+++ b/HelpMyStreet.Utils/HelpMyStreet.Utils/HelpMyStreet.Utils.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
     <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.1" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
   </ItemGroup>
 


### PR DESCRIPTION
17 packages were updated in 5 projects:
`Polly`, `Polly.Contrib.DuplicateRequestCollapser`, `Newtonsoft.Json`, `Microsoft.Azure.Services.AppAuthentication`, `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Logging.Abstractions`, `Microsoft.Extensions.Logging`, `Microsoft.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.SqlServer`, `Microsoft.EntityFrameworkCore.Design`, `Microsoft.Extensions.Http`, `NUnit3TestAdapter`, `Moq`, `MediatR`, `Microsoft.NET.Test.Sdk`, `System.Data.SqlClient`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `Polly` to `7.2.1` from `7.2.0`
`Polly 7.2.1` was published at `2020-05-02T11:53:40Z`, 4 months ago

2 project updates:
Updated `HelpMyStreet.Utils\HelpMyStreet.Cache\HelpMyStreet.Cache.csproj` to `Polly` `7.2.1` from `7.2.0`
Updated `HelpMyStreet.Utils\HelpMyStreet.Utils\HelpMyStreet.Utils.csproj` to `Polly` `7.2.1` from `7.2.0`

[Polly 7.2.1 on NuGet.org](https://www.nuget.org/packages/Polly/7.2.1)

NuKeeper has generated a patch update of `Polly.Contrib.DuplicateRequestCollapser` to `0.2.1` from `0.2.0`
`Polly.Contrib.DuplicateRequestCollapser 0.2.1` was published at `2020-06-05T18:31:02Z`, 3 months ago

3 project updates:
Updated `HelpMyStreet.Utils\HelpMyStreet.Cache\HelpMyStreet.Cache.csproj` to `Polly.Contrib.DuplicateRequestCollapser` `0.2.1` from `0.2.0`
Updated `HelpMyStreet.Utils\HelpMyStreet.UnitTests\HelpMyStreet.UnitTests.csproj` to `Polly.Contrib.DuplicateRequestCollapser` `0.2.1` from `0.2.0`
Updated `HelpMyStreet.Utils\HelpMyStreet.Utils\HelpMyStreet.Utils.csproj` to `Polly.Contrib.DuplicateRequestCollapser` `0.2.1` from `0.2.0`

[Polly.Contrib.DuplicateRequestCollapser 0.2.1 on NuGet.org](https://www.nuget.org/packages/Polly.Contrib.DuplicateRequestCollapser/0.2.1)

NuKeeper has generated a major update of `Newtonsoft.Json` to `12.0.3` from `11.0.2`
`Newtonsoft.Json 12.0.3` was published at `2019-11-09T01:27:30Z`, 10 months ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.Utils\HelpMyStreet.Utils.csproj` to `Newtonsoft.Json` `12.0.3` from `11.0.2`

[Newtonsoft.Json 12.0.3 on NuGet.org](https://www.nuget.org/packages/Newtonsoft.Json/12.0.3)

NuKeeper has generated a minor update of `Microsoft.Azure.Services.AppAuthentication` to `1.5.0` from `1.4.0`
`Microsoft.Azure.Services.AppAuthentication 1.5.0` was published at `2020-05-21T03:08:32Z`, 4 months ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.Utils\HelpMyStreet.Utils.csproj` to `Microsoft.Azure.Services.AppAuthentication` `1.5.0` from `1.4.0`

[Microsoft.Azure.Services.AppAuthentication 1.5.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Azure.Services.AppAuthentication/1.5.0)

NuKeeper has generated a major update of `Microsoft.Extensions.DependencyInjection.Abstractions` to `3.1.8` from `2.2.0`
`Microsoft.Extensions.DependencyInjection.Abstractions 3.1.8` was published at `2020-09-08T14:10:13Z`, 15 days ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.Cache\HelpMyStreet.Cache.csproj` to `Microsoft.Extensions.DependencyInjection.Abstractions` `3.1.8` from `2.2.0`

[Microsoft.Extensions.DependencyInjection.Abstractions 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions/3.1.8)

NuKeeper has generated a major update of `Microsoft.Extensions.DependencyInjection` to `3.1.8` from `2.2.0`
`Microsoft.Extensions.DependencyInjection 3.1.8` was published at `2020-09-08T14:11:06Z`, 15 days ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.UnitTests\HelpMyStreet.UnitTests.csproj` to `Microsoft.Extensions.DependencyInjection` `3.1.8` from `2.2.0`

[Microsoft.Extensions.DependencyInjection 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection/3.1.8)

NuKeeper has generated a major update of `Microsoft.Extensions.Logging.Abstractions` to `3.1.8` from `2.2.0`
`Microsoft.Extensions.Logging.Abstractions 3.1.8` was published at `2020-09-08T14:11:29Z`, 15 days ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.Utils\HelpMyStreet.Utils.csproj` to `Microsoft.Extensions.Logging.Abstractions` `3.1.8` from `2.2.0`

[Microsoft.Extensions.Logging.Abstractions 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/3.1.8)

NuKeeper has generated a major update of `Microsoft.Extensions.Logging` to `3.1.8` from `2.2.0`
`Microsoft.Extensions.Logging 3.1.8` was published at `2020-09-08T14:10:46Z`, 15 days ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.Cache\HelpMyStreet.Cache.csproj` to `Microsoft.Extensions.Logging` `3.1.8` from `2.2.0`

[Microsoft.Extensions.Logging 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Logging/3.1.8)

NuKeeper has generated a major update of `Microsoft.EntityFrameworkCore` to `3.1.8` from `2.2.0`
`Microsoft.EntityFrameworkCore 3.1.8` was published at `2020-09-08T14:10:01Z`, 15 days ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.PostcodeCoordinates.EF\HelpMyStreet.PostcodeCoordinates.EF.csproj` to `Microsoft.EntityFrameworkCore` `3.1.8` from `2.2.0`

[Microsoft.EntityFrameworkCore 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/3.1.8)

NuKeeper has generated a major update of `Microsoft.EntityFrameworkCore.SqlServer` to `3.1.8` from `2.2.0`
`Microsoft.EntityFrameworkCore.SqlServer 3.1.8` was published at `2020-09-08T14:09:52Z`, 15 days ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.PostcodeCoordinates.EF\HelpMyStreet.PostcodeCoordinates.EF.csproj` to `Microsoft.EntityFrameworkCore.SqlServer` `3.1.8` from `2.2.0`

[Microsoft.EntityFrameworkCore.SqlServer 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer/3.1.8)

NuKeeper has generated a major update of `Microsoft.EntityFrameworkCore.Design` to `3.1.8` from `2.2.0`
`Microsoft.EntityFrameworkCore.Design 3.1.8` was published at `2020-09-08T14:09:55Z`, 15 days ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.PostcodeCoordinates.EF\HelpMyStreet.PostcodeCoordinates.EF.csproj` to `Microsoft.EntityFrameworkCore.Design` `3.1.8` from `2.2.0`

[Microsoft.EntityFrameworkCore.Design 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Design/3.1.8)

NuKeeper has generated a major update of `Microsoft.Extensions.Http` to `3.1.8` from `2.2.0`
`Microsoft.Extensions.Http 3.1.8` was published at `2020-09-08T14:10:37Z`, 15 days ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.Utils\HelpMyStreet.Utils.csproj` to `Microsoft.Extensions.Http` `3.1.8` from `2.2.0`

[Microsoft.Extensions.Http 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http/3.1.8)

NuKeeper has generated a minor update of `NUnit3TestAdapter` to `3.17.0` from `3.15.1`
`NUnit3TestAdapter 3.17.0` was published at `2020-07-11T19:10:58Z`, 2 months ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.UnitTests\HelpMyStreet.UnitTests.csproj` to `NUnit3TestAdapter` `3.17.0` from `3.15.1`

[NUnit3TestAdapter 3.17.0 on NuGet.org](https://www.nuget.org/packages/NUnit3TestAdapter/3.17.0)

NuKeeper has generated a patch update of `Moq` to `4.14.5` from `4.14.0`
`Moq 4.14.5` was published at `2020-07-01T16:48:50Z`, 2 months ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.UnitTests\HelpMyStreet.UnitTests.csproj` to `Moq` `4.14.5` from `4.14.0`

[Moq 4.14.5 on NuGet.org](https://www.nuget.org/packages/Moq/4.14.5)

NuKeeper has generated a minor update of `MediatR` to `8.1.0` from `8.0.1`
`MediatR 8.1.0` was published at `2020-07-27T17:49:48Z`, 2 months ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.Contracts\HelpMyStreet.Contracts.csproj` to `MediatR` `8.1.0` from `8.0.1`

[MediatR 8.1.0 on NuGet.org](https://www.nuget.org/packages/MediatR/8.1.0)

NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `16.7.1` from `16.4.0`
`Microsoft.NET.Test.Sdk 16.7.1` was published at `2020-08-20T09:25:54Z`, 1 month ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.UnitTests\HelpMyStreet.UnitTests.csproj` to `Microsoft.NET.Test.Sdk` `16.7.1` from `16.4.0`

[Microsoft.NET.Test.Sdk 16.7.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.7.1)

NuKeeper has generated a minor update of `System.Data.SqlClient` to `4.8.2` from `4.6.0`
`System.Data.SqlClient 4.8.2` was published at `2020-08-11T14:15:16Z`, 1 month ago

1 project update:
Updated `HelpMyStreet.Utils\HelpMyStreet.Utils\HelpMyStreet.Utils.csproj` to `System.Data.SqlClient` `4.8.2` from `4.6.0`

[System.Data.SqlClient 4.8.2 on NuGet.org](https://www.nuget.org/packages/System.Data.SqlClient/4.8.2)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
